### PR TITLE
Add Dependabot config (npm + NuGet)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # --- Angular frontend (npm) ---
+  - package-ecosystem: "npm"
+    directory: "/celebs-angular"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      # Keep all Angular packages bumped together (they must stay in lockstep,
+      # otherwise compiler/compiler-cli/cli peer deps conflict and break the build).
+      angular:
+        patterns:
+          - "@angular*"
+      # Batch remaining minor/patch updates into a single PR to cut noise.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- React frontend (npm) ---
+  - package-ecosystem: "npm"
+    directory: "/celebs-react"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- .NET API (NuGet) ---
+  - package-ecosystem: "nuget"
+    directory: "/celebs-api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- IMDb scraper (NuGet) ---
+  - package-ecosystem: "nuget"
+    directory: "/ImdbScraper"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to automate dependency updates (there was none before — only security alerts fired).

## Coverage
| Ecosystem | Directory |
|-----------|-----------|
| npm | /celebs-angular |
| npm | /celebs-react |
| nuget | /celebs-api |
| nuget | /ImdbScraper |

## Notes
- Weekly schedule (Mondays), limit 10 open PRs per ecosystem.
- **`@angular*` packages are grouped** so they always bump in lockstep — prevents the `compiler-cli` peer-dependency break we just fixed.
- Other minor/patch updates are batched into a single grouped PR to cut noise; majors still come individually for safer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)